### PR TITLE
Adding video entity

### DIFF
--- a/src/core/cast-member/domain/cast-member.aggregate.ts
+++ b/src/core/cast-member/domain/cast-member.aggregate.ts
@@ -60,7 +60,7 @@ export class CastMember extends AggregateRoot {
     return CastMemberFakeBuilder;
   }
 
-  get entityID() {
+  get entityId() {
     return this.castMemberId;
   }
   toJSON() {

--- a/src/core/category/domain/category.aggregate.ts
+++ b/src/core/category/domain/category.aggregate.ts
@@ -36,7 +36,7 @@ export class Category extends AggregateRoot {
     this.createdAt = props.createdAt ?? new Date();
   }
 
-  get entityID(): ValueObject {
+  get entityId(): ValueObject {
     return this.categoryID;
   }
 

--- a/src/core/genre/domain/genre.aggregate.ts
+++ b/src/core/genre/domain/genre.aggregate.ts
@@ -37,7 +37,7 @@ export class Genre extends AggregateRoot {
     this.createdAt = props.createdAt ?? new Date();
   }
 
-  get entityID(): ValueObject {
+  get entityId(): ValueObject {
     return this.genreId;
   }
 

--- a/src/core/shared/domain/entity.ts
+++ b/src/core/shared/domain/entity.ts
@@ -4,6 +4,6 @@ import { ValueObject } from './value-object';
 export abstract class Entity {
   notification: Notification = new Notification();
 
-  abstract get entityID(): ValueObject;
+  abstract get entityId(): ValueObject;
   abstract toJSON(): any;
 }

--- a/src/core/shared/domain/validators/__tests__/media-file.validator.spec.ts
+++ b/src/core/shared/domain/validators/__tests__/media-file.validator.spec.ts
@@ -1,0 +1,54 @@
+import {
+  InvalidMediaFileMimeTypeError,
+  InvalidMediaFileSizeError,
+  MediaFileValidator,
+} from '../media-file.validator';
+
+describe('MediaFileValidator Unit Tests', () => {
+  const validator = new MediaFileValidator(1024 * 1024, [
+    'image/png',
+    'image/jpeg',
+  ]);
+
+  it('should throw an error if the file size is too large', () => {
+    const data = Buffer.alloc(1024 * 1024 + 1);
+
+    expect(() =>
+      validator.validate({
+        rawName: 'banner.png',
+        mimeType: 'image/png',
+        size: data.length,
+      }),
+    ).toThrow(new InvalidMediaFileSizeError(data.length, validator['maxSize']));
+  });
+
+  it('should throw an error if the file type is invalid', () => {
+    const data = Buffer.alloc(1024);
+
+    expect(() =>
+      validator.validate({
+        rawName: 'banner.pdf',
+        mimeType: 'application/pdf',
+        size: data.length,
+      }),
+    ).toThrow(
+      new InvalidMediaFileMimeTypeError(
+        'application/pdf',
+        validator['validMimeTypes'],
+      ),
+    );
+  });
+
+  it('should return a valid file name', () => {
+    const data = Buffer.alloc(1024);
+
+    const { name } = validator.validate({
+      rawName: 'banner.png',
+      mimeType: 'image/png',
+      size: data.length,
+    });
+
+    expect(name).toMatch(/\.png$/);
+    expect(name).toHaveLength(68);
+  });
+});

--- a/src/core/shared/domain/validators/media-file.validator.ts
+++ b/src/core/shared/domain/validators/media-file.validator.ts
@@ -1,0 +1,67 @@
+import crypto from 'crypto';
+
+export class MediaFileValidator {
+  constructor(
+    private readonly maxSize: number,
+    private readonly validMimeTypes: string[],
+  ) {}
+
+  validate({
+    rawName,
+    mimeType,
+    size,
+  }: {
+    rawName: string;
+    mimeType: string;
+    size: number;
+  }) {
+    if (!this.validateSize(size)) {
+      throw new InvalidMediaFileSizeError(size, this.maxSize);
+    }
+
+    if (!this.validateMimeType(mimeType)) {
+      throw new InvalidMediaFileMimeTypeError(mimeType, this.validMimeTypes);
+    }
+
+    return {
+      name: this.generateRandomName(rawName),
+    };
+  }
+
+  private validateSize(size: number) {
+    return size <= this.maxSize;
+  }
+
+  private validateMimeType(mimeType: string) {
+    return this.validMimeTypes.includes(mimeType);
+  }
+
+  private generateRandomName(rawName: string) {
+    const extension = rawName.split('.').pop();
+
+    return (
+      crypto
+        .createHash('sha256')
+        .update(rawName + Math.random() + Date.now())
+        .digest('hex') +
+      '.' +
+      extension
+    );
+  }
+}
+
+export class InvalidMediaFileSizeError extends Error {
+  constructor(actualSize: number, maxSize: number) {
+    super(`Invalid media file size: ${actualSize} > ${maxSize}`);
+  }
+}
+
+export class InvalidMediaFileMimeTypeError extends Error {
+  constructor(actualMimeType: string, validMimeTypes: string[]) {
+    super(
+      `Invalid media file mime type: ${actualMimeType} not in ${validMimeTypes.join(
+        ', ',
+      )}`,
+    );
+  }
+}

--- a/src/core/shared/domain/value-objects/audio-video-media.vo.ts
+++ b/src/core/shared/domain/value-objects/audio-video-media.vo.ts
@@ -1,0 +1,46 @@
+import { ValueObject } from '../value-object';
+
+export enum AudioVideoMediaStatus {
+  PENDING = 'pending',
+  PROCESSING = 'processing',
+  COMPLETED = 'completed',
+  FAILED = 'failed',
+}
+
+export abstract class AudioVideoMedia extends ValueObject {
+  readonly name: string;
+  readonly rawLocation: string;
+  readonly encodedLocation: string | null;
+  readonly status: AudioVideoMediaStatus;
+
+  constructor({
+    name,
+    rawLocation,
+    encodedLocation,
+    status,
+  }: {
+    name: string;
+    rawLocation: string;
+    encodedLocation?: string;
+    status: AudioVideoMediaStatus;
+  }) {
+    super();
+    this.name = name;
+    this.rawLocation = rawLocation;
+    this.encodedLocation = encodedLocation ?? null;
+    this.status = status;
+  }
+
+  get rawUrl(): string {
+    return `${this.rawLocation}/${this.name}`;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      rawLocation: this.rawLocation,
+      encodedLocation: this.encodedLocation,
+      status: this.status,
+    };
+  }
+}

--- a/src/core/shared/domain/value-objects/image-media.vo.ts
+++ b/src/core/shared/domain/value-objects/image-media.vo.ts
@@ -1,0 +1,23 @@
+import { ValueObject } from '../value-object';
+
+export abstract class ImageMedia extends ValueObject {
+  readonly name: string;
+  readonly location: string;
+
+  constructor({ name, location }: { name: string; location: string }) {
+    super();
+    this.name = name;
+    this.location = location;
+  }
+
+  get url(): string {
+    return `${this.location}/${this.name}`;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      location: this.location,
+    };
+  }
+}

--- a/src/core/shared/infra/db/in-memory/__tests__/in-memory-searchable.repository.spec.ts
+++ b/src/core/shared/infra/db/in-memory/__tests__/in-memory-searchable.repository.spec.ts
@@ -10,19 +10,19 @@ type StubEntityConstructorProps = {
 };
 
 class StubEntity extends Entity {
-  entityID: Uuid;
+  entityId: Uuid;
   name: string;
 
   constructor(props: StubEntityConstructorProps) {
     super();
 
-    this.entityID = props.entityID || new Uuid();
+    this.entityId = props.entityID || new Uuid();
     this.name = props.name;
   }
 
   toJSON() {
     return {
-      entityID: this.entityID.id,
+      entityID: this.entityId.id,
       name: this.name,
     };
   }

--- a/src/core/shared/infra/db/in-memory/__tests__/in-memory.repository.spec.ts
+++ b/src/core/shared/infra/db/in-memory/__tests__/in-memory.repository.spec.ts
@@ -9,19 +9,19 @@ type StubEntityConstructor = {
 };
 
 class StubEntity extends Entity {
-  entityID: Uuid;
+  entityId: Uuid;
   name: string;
 
   constructor(props: StubEntityConstructor) {
     super();
 
-    this.entityID = props.entityID || new Uuid();
+    this.entityId = props.entityID || new Uuid();
     this.name = props.name;
   }
 
   toJSON() {
     return {
-      entityID: this.entityID.id,
+      entityID: this.entityId.id,
       name: this.name,
     };
   }
@@ -80,7 +80,7 @@ describe('InMemoryRepository Unit Tests', () => {
     const entity = new StubEntity({ name: 'Test' });
 
     await expect(repo.update(entity)).rejects.toThrow(
-      new NotFoundError(entity.entityID, StubEntity),
+      new NotFoundError(entity.entityId, StubEntity),
     );
   });
 
@@ -90,7 +90,7 @@ describe('InMemoryRepository Unit Tests', () => {
     await repo.insert(entity);
 
     const entityUpdated = new StubEntity({
-      entityID: entity.entityID,
+      entityID: entity.entityId,
       name: 'Test Updated',
     });
 
@@ -118,7 +118,7 @@ describe('InMemoryRepository Unit Tests', () => {
 
     await repo.insert(entity);
 
-    await repo.delete(entity.entityID);
+    await repo.delete(entity.entityId);
     expect(repo.items).toHaveLength(0);
   });
 });

--- a/src/core/shared/infra/db/in-memory/in-memory.repository.ts
+++ b/src/core/shared/infra/db/in-memory/in-memory.repository.ts
@@ -29,11 +29,11 @@ export abstract class InMemoryRepository<
 
   async update(entity: E): Promise<void> {
     const indexFound = this.items.findIndex((item) =>
-      item.entityID.equals(entity.entityID),
+      item.entityId.equals(entity.entityId),
     );
 
     if (indexFound === -1) {
-      throw new NotFoundError(entity.entityID, this.getEntity());
+      throw new NotFoundError(entity.entityId, this.getEntity());
     }
 
     this.items[indexFound] = entity;
@@ -41,7 +41,7 @@ export abstract class InMemoryRepository<
 
   async delete(entityID: EntityID): Promise<void> {
     const indexFound = this.items.findIndex((item) =>
-      item.entityID.equals(entityID),
+      item.entityId.equals(entityID),
     );
 
     if (indexFound === -1) {
@@ -52,7 +52,7 @@ export abstract class InMemoryRepository<
   }
 
   async findByID(entityID: EntityID): Promise<E | null> {
-    const entity = this.items.find((item) => item.entityID.equals(entityID));
+    const entity = this.items.find((item) => item.entityId.equals(entityID));
 
     return typeof entity === 'undefined' ? null : entity;
   }
@@ -63,7 +63,7 @@ export abstract class InMemoryRepository<
 
   async findByIds(ids: EntityID[]): Promise<E[]> {
     return this.items.filter((item) => {
-      return ids.some((id) => item.entityID.equals(id));
+      return ids.some((id) => item.entityId.equals(id));
     });
   }
 
@@ -84,7 +84,7 @@ export abstract class InMemoryRepository<
     const notExistsId = new Set<EntityID>();
 
     ids.forEach((id) => {
-      const item = this.items.find((item) => item.entityID.equals(id));
+      const item = this.items.find((item) => item.entityId.equals(id));
 
       item ? existsId.add(id) : notExistsId.add(id);
     });

--- a/src/core/video/domain/__tests__/banner.vo.spec.ts
+++ b/src/core/video/domain/__tests__/banner.vo.spec.ts
@@ -1,0 +1,59 @@
+import {
+  InvalidMediaFileMimeTypeError,
+  InvalidMediaFileSizeError,
+} from '@core/shared/domain/validators/media-file.validator';
+import { Banner } from '../banner.vo';
+import { VideoId } from '../video.aggregate';
+
+describe('Banner Unit Tests', () => {
+  it('should create a Banner object from a valid file', () => {
+    const data = Buffer.alloc(1024);
+
+    const videoId = new VideoId();
+
+    const [banner, error] = Banner.createFromFile({
+      rawName: 'banner.png',
+      mimeType: 'image/png',
+      size: data.length,
+      videoId,
+    }).asArray();
+
+    expect(error).toBeNull();
+    expect(banner).toBeInstanceOf(Banner);
+    expect(banner.name).toMatch(/\.png$/);
+    expect(banner.location).toBe(`videos/${videoId.id}/imagens`);
+  });
+
+  it('should throw an error if the file size is too large', () => {
+    const data = Buffer.alloc(Banner.maxSize + 1);
+
+    const videoId = new VideoId();
+
+    const [banner, error] = Banner.createFromFile({
+      rawName: 'banner.png',
+      mimeType: 'image/png',
+      size: data.length,
+      videoId,
+    }).asArray();
+
+    expect(banner).toBeNull();
+    expect(error).toBeInstanceOf(InvalidMediaFileSizeError);
+  });
+
+  it('should throw an error if the file type is invalid', () => {
+    const data = Buffer.alloc(1024);
+
+    const videoId = new VideoId();
+
+    const [banner, error] = Banner.createFromFile({
+      rawName: 'banner.pdf',
+      mimeType: 'application/pdf',
+      size: data.length,
+      videoId,
+    }).asArray();
+
+    expect(banner).toBeNull();
+
+    expect(error).toBeInstanceOf(InvalidMediaFileMimeTypeError);
+  });
+});

--- a/src/core/video/domain/__tests__/rating.vo.spec.ts
+++ b/src/core/video/domain/__tests__/rating.vo.spec.ts
@@ -1,0 +1,71 @@
+import { InvalidRatingError, Rating, RatingValues } from '../rating.vo';
+
+describe('Rating Unit Tests', () => {
+  it('should create a valid rating', () => {
+    const rating = Rating.with(RatingValues.R10);
+
+    expect(rating).toBeInstanceOf(Rating);
+    expect(rating.value).toBe(RatingValues.R10);
+  });
+
+  it('should fail when creating an invalid rating', () => {
+    expect(() => Rating.with('R20' as any)).toThrow(InvalidRatingError);
+  });
+
+  it('should create a RL rating', () => {
+    const rating = Rating.createRL();
+
+    expect(rating).toBeInstanceOf(Rating);
+    expect(rating.value).toBe(RatingValues.RL);
+  });
+
+  it('should create a R10 rating', () => {
+    const rating = Rating.createR10();
+
+    expect(rating).toBeInstanceOf(Rating);
+    expect(rating.value).toBe(RatingValues.R10);
+  });
+
+  it('should create a R12 rating', () => {
+    const rating = Rating.createR12();
+
+    expect(rating).toBeInstanceOf(Rating);
+    expect(rating.value).toBe(RatingValues.R12);
+  });
+
+  it('should create a R14 rating', () => {
+    const rating = Rating.createR14();
+
+    expect(rating).toBeInstanceOf(Rating);
+    expect(rating.value).toBe(RatingValues.R14);
+  });
+
+  it('should create a R16 rating', () => {
+    const rating = Rating.createR16();
+
+    expect(rating).toBeInstanceOf(Rating);
+    expect(rating.value).toBe(RatingValues.R16);
+  });
+
+  it('should create a R18 rating', () => {
+    const rating = Rating.createR18();
+
+    expect(rating).toBeInstanceOf(Rating);
+    expect(rating.value).toBe(RatingValues.R18);
+  });
+
+  it('should create a valid rating using create method', () => {
+    const [rating, error] = Rating.create(RatingValues.R10).asArray();
+
+    expect(rating).toBeInstanceOf(Rating);
+    expect(rating.value).toBe(RatingValues.R10);
+    expect(error).toBeNull();
+  });
+
+  it('should fail when creating an invalid rating using create method', () => {
+    const [rating, error] = Rating.create('R20' as any).asArray();
+
+    expect(rating).toBeNull();
+    expect(error).toBeInstanceOf(InvalidRatingError);
+  });
+});

--- a/src/core/video/domain/__tests__/video-fake.builder.spec.ts
+++ b/src/core/video/domain/__tests__/video-fake.builder.spec.ts
@@ -1,0 +1,591 @@
+import { Chance } from 'chance';
+import { VideoFakeBuilder } from '../video-fake.builder';
+import { VideoId } from '../video.aggregate';
+import { CategoryId } from '@core/category/domain/category.aggregate';
+import { CastMemberId } from '@core/cast-member/domain/cast-member.aggregate';
+import { GenreId } from '@core/genre/domain/genre.aggregate';
+import { Banner } from '../banner.vo';
+import { Rating } from '../rating.vo';
+import { ThumbnailHalf } from '../thumbnail-half.vo';
+import { Thumbnail } from '../thumbnail.vo';
+import { Trailer } from '../trailer.vo';
+import { VideoMedia } from '../video-media.vo';
+
+describe('VideoFakeBuilder Unit Tests', () => {
+  describe('videoId prop', () => {
+    const faker = VideoFakeBuilder.aVideoWithoutMedias();
+
+    it('should throw error when any with methods has called', () => {
+      expect(() => faker.videoId).toThrow(
+        new Error(`Property videoId not have a factory, use 'with' methods`),
+      );
+    });
+
+    it('should be undefined', () => {
+      expect(faker['_videoId']).toBeUndefined();
+    });
+
+    test('withVideoId', () => {
+      const videoId = new VideoId();
+
+      const $this = faker.withVideoId(videoId);
+
+      expect($this).toBeInstanceOf(VideoFakeBuilder);
+      expect($this['_videoId']).toBe(videoId);
+
+      faker.withVideoId(() => videoId);
+
+      //@ts-expect-error _videoId is a callable
+      expect(faker['_videoId']()).toBe(videoId);
+
+      expect(faker.videoId).toBe(videoId);
+    });
+
+    it('should pass index to videoId factory', () => {
+      let mockFactory = jest.fn(() => new VideoId());
+
+      faker.withVideoId(mockFactory);
+      faker.build();
+
+      expect(mockFactory).toHaveBeenCalledTimes(1);
+
+      const genreId = new VideoId();
+
+      mockFactory = jest.fn(() => genreId);
+
+      const fakerMany = VideoFakeBuilder.theVideosWithoutMedias(2);
+
+      fakerMany.withVideoId(mockFactory);
+      fakerMany.build();
+
+      expect(mockFactory).toHaveBeenCalledTimes(2);
+
+      expect(fakerMany.build()[0].videoId).toBe(genreId);
+      expect(fakerMany.build()[1].videoId).toBe(genreId);
+    });
+  });
+
+  describe('title prop', () => {
+    const faker = VideoFakeBuilder.aVideoWithoutMedias();
+
+    it('should be a function', () => {
+      expect(faker['_title']).toBeInstanceOf(Function);
+    });
+
+    it('should call the word method', () => {
+      const chance = Chance();
+      const wordSpy = jest.spyOn(chance, 'word');
+
+      faker['chance'] = chance;
+      faker.build();
+
+      expect(wordSpy).toHaveBeenCalled();
+    });
+
+    test('withTitle', () => {
+      const $this = faker.withTitle('Harry Potter');
+
+      expect($this).toBeInstanceOf(VideoFakeBuilder);
+      expect($this['_title']).toBe('Harry Potter');
+
+      faker.withTitle(() => 'Harry Potter');
+
+      //@ts-expect-error _title is a callable
+      expect(faker['_title']()).toBe('Harry Potter');
+      expect(faker.title).toBe('Harry Potter');
+    });
+
+    it('should pass index to title factory', () => {
+      faker.withTitle((index) => `Harry Potter ${index}`);
+
+      const video = faker.build();
+
+      expect(video.title).toBe('Harry Potter 0');
+
+      const fakerMany = VideoFakeBuilder.theVideosWithoutMedias(2);
+
+      fakerMany.withTitle((index) => `Harry Potter ${index}`);
+      const categories = fakerMany.build();
+
+      expect(categories[0].title).toBe('Harry Potter 0');
+      expect(categories[1].title).toBe('Harry Potter 1');
+    });
+
+    test('invalid too long case', () => {
+      const $this = faker.withInvalidTitleTooLong();
+
+      expect($this).toBeInstanceOf(VideoFakeBuilder);
+      expect(faker['_title'].length).toBe(256);
+
+      const tooLong = 'a'.repeat(256);
+
+      faker.withInvalidTitleTooLong(tooLong);
+
+      expect(faker['_title'].length).toBe(256);
+      expect(faker['_title']).toBe(tooLong);
+    });
+  });
+
+  describe('categoriesId prop', () => {
+    const faker = VideoFakeBuilder.aVideoWithoutMedias();
+    it('should be empty', () => {
+      expect(faker['_categoriesId']).toBeInstanceOf(Array);
+    });
+
+    test('withCategoryId', () => {
+      const categoryId1 = new CategoryId();
+
+      const $this = faker.addCategoryId(categoryId1);
+      expect($this).toBeInstanceOf(VideoFakeBuilder);
+      expect(faker['_categoriesId']).toStrictEqual([categoryId1]);
+
+      const categoryId2 = new CategoryId();
+
+      faker.addCategoryId(() => categoryId2);
+
+      expect([
+        faker['_categoriesId'][0],
+        // @ts-expect-error _categoriesId is a callable
+        faker['_categoriesId'][1](),
+      ]).toStrictEqual([categoryId1, categoryId2]);
+    });
+
+    it('should pass index to categoriesId factory', () => {
+      const categoriesId = [new CategoryId(), new CategoryId()];
+      faker.addCategoryId((index) => categoriesId[index]);
+      const genre = faker.build();
+
+      expect(genre.categoriesId.get(categoriesId[0].id)).toBe(categoriesId[0]);
+
+      const fakerMany = VideoFakeBuilder.theVideosWithoutMedias(2);
+      fakerMany.addCategoryId((index) => categoriesId[index]);
+      const genres = fakerMany.build();
+
+      expect(genres[0].categoriesId.get(categoriesId[0].id)).toBe(
+        categoriesId[0],
+      );
+
+      expect(genres[1].categoriesId.get(categoriesId[1].id)).toBe(
+        categoriesId[1],
+      );
+    });
+  });
+
+  describe('createdAt prop', () => {
+    const faker = VideoFakeBuilder.aVideoWithoutMedias();
+
+    it('should throw error when any with methods has called', () => {
+      const fakerVideo = VideoFakeBuilder.aVideoWithoutMedias();
+
+      expect(() => fakerVideo.createdAt).toThrow(
+        new Error("Property createdAt not have a factory, use 'with' methods"),
+      );
+    });
+
+    test('should be undefined', () => {
+      expect(faker['_createdAt']).toBeUndefined();
+    });
+
+    test('withCreatedAt', () => {
+      const date = new Date();
+
+      const $this = faker.withCreatedAt(date);
+      expect($this).toBeInstanceOf(VideoFakeBuilder);
+
+      expect(faker['_createdAt']).toBe(date);
+
+      faker.withCreatedAt(() => date);
+      //@ts-expect-error _createdAt is a callable
+      expect(faker['_createdAt']()).toBe(date);
+      expect(faker.createdAt).toBe(date);
+    });
+
+    test('should pass index to createdAt factory', () => {
+      const date = new Date();
+      faker.withCreatedAt((index) => new Date(date.getTime() + index + 2));
+      const genre = faker.build();
+      expect(genre.createdAt.getTime()).toBe(date.getTime() + 2);
+
+      const fakerMany = VideoFakeBuilder.theVideosWithoutMedias(2);
+      fakerMany.withCreatedAt((index) => new Date(date.getTime() + index + 2));
+      const categories = fakerMany.build();
+
+      expect(categories[0].createdAt.getTime()).toBe(date.getTime() + 2);
+      expect(categories[1].createdAt.getTime()).toBe(date.getTime() + 3);
+    });
+  });
+
+  it('should create a video without medias', () => {
+    let video = VideoFakeBuilder.aVideoWithoutMedias().build();
+
+    expect(video.videoId).toBeInstanceOf(VideoId);
+    expect(typeof video.title === 'string').toBeTruthy();
+    expect(typeof video.description === 'string').toBeTruthy();
+    expect(typeof video.releasedYear === 'number').toBeTruthy();
+    expect(typeof video.duration === 'number').toBeTruthy();
+    expect(video.rating).toEqual(Rating.createRL());
+    expect(video.isOpened).toBeTruthy();
+    expect(video.isPublished).toBeFalsy();
+    expect(video.banner).toBeNull();
+    expect(video.thumbnail).toBeNull();
+    expect(video.thumbnailHalf).toBeNull();
+    expect(video.trailer).toBeNull();
+    expect(video.video).toBeNull();
+    expect(video.categoriesId).toBeInstanceOf(Map);
+    expect(video.categoriesId.size).toBe(1);
+    expect(video.categoriesId.values().next().value).toBeInstanceOf(CategoryId);
+    expect(video.genresId).toBeInstanceOf(Map);
+    expect(video.genresId.size).toBe(1);
+    expect(video.genresId.values().next().value).toBeInstanceOf(GenreId);
+    expect(video.castMembersId).toBeInstanceOf(Map);
+    expect(video.castMembersId.size).toBe(1);
+    expect(video.castMembersId.values().next().value).toBeInstanceOf(
+      CastMemberId,
+    );
+    expect(video.createdAt).toBeInstanceOf(Date);
+
+    const createdAt = new Date();
+    const videoId = new VideoId();
+    const categoryId1 = new CategoryId();
+    const categoryId2 = new CategoryId();
+    const genreId1 = new GenreId();
+    const genreId2 = new GenreId();
+    const castMemberId1 = new CastMemberId();
+    const castMemberId2 = new CastMemberId();
+    video = VideoFakeBuilder.aVideoWithoutMedias()
+      .withVideoId(videoId)
+      .withTitle('name test')
+      .withDescription('description test')
+      .withReleasedYear(2020)
+      .withDuration(90)
+      .withRating(Rating.createR10())
+      .withMarkAsClosed()
+      .addCategoryId(categoryId1)
+      .addCategoryId(categoryId2)
+      .addGenreId(genreId1)
+      .addGenreId(genreId2)
+      .addCastMemberId(castMemberId1)
+      .addCastMemberId(castMemberId2)
+      .withCreatedAt(createdAt)
+      .build();
+    expect(video.videoId.id).toBe(videoId.id);
+    expect(video.title).toBe('name test');
+    expect(video.description).toBe('description test');
+    expect(video.releasedYear).toBe(2020);
+    expect(video.duration).toBe(90);
+    expect(video.rating).toEqual(Rating.createR10());
+    expect(video.isOpened).toBeFalsy();
+    expect(video.isPublished).toBeFalsy();
+    expect(video.banner).toBeNull();
+    expect(video.thumbnail).toBeNull();
+    expect(video.thumbnailHalf).toBeNull();
+    expect(video.trailer).toBeNull();
+    expect(video.video).toBeNull();
+    expect(video.categoriesId).toBeInstanceOf(Map);
+    expect(video.categoriesId.get(categoryId1.id)).toBe(categoryId1);
+    expect(video.categoriesId.get(categoryId2.id)).toBe(categoryId2);
+    expect(video.genresId).toBeInstanceOf(Map);
+    expect(video.genresId.get(genreId1.id)).toBe(genreId1);
+    expect(video.genresId.get(genreId2.id)).toBe(genreId2);
+    expect(video.castMembersId).toBeInstanceOf(Map);
+    expect(video.castMembersId.get(castMemberId1.id)).toBe(castMemberId1);
+    expect(video.castMembersId.get(castMemberId2.id)).toBe(castMemberId2);
+    expect(video.createdAt).toEqual(createdAt);
+  });
+
+  it('should create a video with medias', () => {
+    let video = VideoFakeBuilder.aVideoWithAllMedias().build();
+
+    expect(video.videoId).toBeInstanceOf(VideoId);
+    expect(typeof video.title === 'string').toBeTruthy();
+    expect(typeof video.description === 'string').toBeTruthy();
+    expect(typeof video.releasedYear === 'number').toBeTruthy();
+    expect(typeof video.duration === 'number').toBeTruthy();
+    expect(video.rating).toEqual(Rating.createRL());
+    expect(video.isOpened).toBeTruthy();
+    expect(video.isPublished).toBeFalsy();
+    expect(video.banner).toBeInstanceOf(Banner);
+    expect(video.thumbnail).toBeInstanceOf(Thumbnail);
+    expect(video.thumbnailHalf).toBeInstanceOf(ThumbnailHalf);
+    expect(video.trailer).toBeInstanceOf(Trailer);
+    expect(video.video).toBeInstanceOf(VideoMedia);
+    expect(video.categoriesId).toBeInstanceOf(Map);
+    expect(video.categoriesId.size).toBe(1);
+    expect(video.categoriesId.values().next().value).toBeInstanceOf(CategoryId);
+    expect(video.genresId).toBeInstanceOf(Map);
+    expect(video.genresId.size).toBe(1);
+    expect(video.genresId.values().next().value).toBeInstanceOf(GenreId);
+    expect(video.castMembersId).toBeInstanceOf(Map);
+    expect(video.castMembersId.size).toBe(1);
+    expect(video.castMembersId.values().next().value).toBeInstanceOf(
+      CastMemberId,
+    );
+    expect(video.createdAt).toBeInstanceOf(Date);
+
+    const createdAt = new Date();
+    const videoId = new VideoId();
+    const categoryId1 = new CategoryId();
+    const categoryId2 = new CategoryId();
+    const genreId1 = new GenreId();
+    const genreId2 = new GenreId();
+    const castMemberId1 = new CastMemberId();
+    const castMemberId2 = new CastMemberId();
+    const banner = new Banner({
+      location: 'location',
+      name: 'name',
+    });
+    const thumbnail = new Thumbnail({
+      location: 'location',
+      name: 'name',
+    });
+    const thumbnailHalf = new ThumbnailHalf({
+      location: 'location',
+      name: 'name',
+    });
+    const trailer = Trailer.create({
+      rawLocation: 'rawLocation',
+      name: 'name',
+    });
+    const videoMedia = VideoMedia.create({
+      rawLocation: 'rawLocation',
+      name: 'name',
+    });
+    video = VideoFakeBuilder.aVideoWithAllMedias()
+      .withVideoId(videoId)
+      .withTitle('name test')
+      .withDescription('description test')
+      .withReleasedYear(2020)
+      .withDuration(90)
+      .withRating(Rating.createR10())
+      .withMarkAsClosed()
+      .addCategoryId(categoryId1)
+      .addCategoryId(categoryId2)
+      .addGenreId(genreId1)
+      .addGenreId(genreId2)
+      .addCastMemberId(castMemberId1)
+      .addCastMemberId(castMemberId2)
+      .withBanner(banner)
+      .withThumbnail(thumbnail)
+      .withThumbnailHalf(thumbnailHalf)
+      .withTrailer(trailer)
+      .withVideo(videoMedia)
+      .withCreatedAt(createdAt)
+      .build();
+    expect(video.videoId.id).toBe(videoId.id);
+    expect(video.title).toBe('name test');
+    expect(video.description).toBe('description test');
+    expect(video.releasedYear).toBe(2020);
+    expect(video.duration).toBe(90);
+    expect(video.rating).toEqual(Rating.createR10());
+    expect(video.isOpened).toBeFalsy();
+    expect(video.isPublished).toBeFalsy();
+    expect(video.banner).toBe(banner);
+    expect(video.thumbnail).toBe(thumbnail);
+    expect(video.thumbnailHalf).toBe(thumbnailHalf);
+    expect(video.trailer).toBe(trailer);
+    expect(video.video).toBe(videoMedia);
+    expect(video.categoriesId).toBeInstanceOf(Map);
+    expect(video.categoriesId.get(categoryId1.id)).toBe(categoryId1);
+    expect(video.categoriesId.get(categoryId2.id)).toBe(categoryId2);
+    expect(video.genresId).toBeInstanceOf(Map);
+    expect(video.genresId.get(genreId1.id)).toBe(genreId1);
+    expect(video.genresId.get(genreId2.id)).toBe(genreId2);
+    expect(video.castMembersId).toBeInstanceOf(Map);
+    expect(video.castMembersId.get(castMemberId1.id)).toBe(castMemberId1);
+    expect(video.castMembersId.get(castMemberId2.id)).toBe(castMemberId2);
+    expect(video.createdAt).toEqual(createdAt);
+  });
+
+  it('should create many videos without medias', () => {
+    const faker = VideoFakeBuilder.theVideosWithoutMedias(2);
+    let videos = faker.build();
+    videos.forEach((video) => {
+      expect(video.videoId).toBeInstanceOf(VideoId);
+      expect(typeof video.title === 'string').toBeTruthy();
+      expect(typeof video.description === 'string').toBeTruthy();
+      expect(typeof video.releasedYear === 'number').toBeTruthy();
+      expect(typeof video.duration === 'number').toBeTruthy();
+      expect(video.rating).toEqual(Rating.createRL());
+      expect(video.isOpened).toBeTruthy();
+      expect(video.isPublished).toBeFalsy();
+      expect(video.banner).toBeNull();
+      expect(video.thumbnail).toBeNull();
+      expect(video.thumbnailHalf).toBeNull();
+      expect(video.trailer).toBeNull();
+      expect(video.video).toBeNull();
+      expect(video.categoriesId).toBeInstanceOf(Map);
+      expect(video.categoriesId.size).toBe(1);
+      expect(video.categoriesId.values().next().value).toBeInstanceOf(
+        CategoryId,
+      );
+      expect(video.genresId).toBeInstanceOf(Map);
+      expect(video.genresId.size).toBe(1);
+      expect(video.genresId.values().next().value).toBeInstanceOf(GenreId);
+      expect(video.castMembersId).toBeInstanceOf(Map);
+      expect(video.castMembersId.size).toBe(1);
+      expect(video.castMembersId.values().next().value).toBeInstanceOf(
+        CastMemberId,
+      );
+      expect(video.createdAt).toBeInstanceOf(Date);
+    });
+
+    const createdAt = new Date();
+    const videoId = new VideoId();
+    const categoryId1 = new CategoryId();
+    const categoryId2 = new CategoryId();
+    const genreId1 = new GenreId();
+    const genreId2 = new GenreId();
+    const castMemberId1 = new CastMemberId();
+    const castMemberId2 = new CastMemberId();
+    videos = VideoFakeBuilder.theVideosWithoutMedias(2)
+      .withVideoId(videoId)
+      .withTitle('name test')
+      .withDescription('description test')
+      .withReleasedYear(2020)
+      .withDuration(90)
+      .withRating(Rating.createR10())
+      .withMarkAsClosed()
+      .addCategoryId(categoryId1)
+      .addCategoryId(categoryId2)
+      .addGenreId(genreId1)
+      .addGenreId(genreId2)
+      .addCastMemberId(castMemberId1)
+      .addCastMemberId(castMemberId2)
+      .withCreatedAt(createdAt)
+      .build();
+    videos.forEach((video) => {
+      expect(video.videoId.id).toBe(videoId.id);
+      expect(video.title).toBe('name test');
+      expect(video.description).toBe('description test');
+      expect(video.releasedYear).toBe(2020);
+      expect(video.duration).toBe(90);
+      expect(video.rating).toEqual(Rating.createR10());
+      expect(video.isOpened).toBeFalsy();
+      expect(video.isPublished).toBeFalsy();
+      expect(video.banner).toBeNull();
+      expect(video.thumbnail).toBeNull();
+      expect(video.thumbnailHalf).toBeNull();
+      expect(video.trailer).toBeNull();
+      expect(video.video).toBeNull();
+      expect(video.categoriesId).toBeInstanceOf(Map);
+      expect(video.categoriesId.get(categoryId1.id)).toBe(categoryId1);
+      expect(video.categoriesId.get(categoryId2.id)).toBe(categoryId2);
+      expect(video.genresId).toBeInstanceOf(Map);
+      expect(video.genresId.get(genreId1.id)).toBe(genreId1);
+      expect(video.genresId.get(genreId2.id)).toBe(genreId2);
+      expect(video.castMembersId).toBeInstanceOf(Map);
+      expect(video.castMembersId.get(castMemberId1.id)).toBe(castMemberId1);
+      expect(video.castMembersId.get(castMemberId2.id)).toBe(castMemberId2);
+      expect(video.createdAt).toEqual(createdAt);
+    });
+  });
+
+  it('should create many videos with medias', () => {
+    const faker = VideoFakeBuilder.theVideosWithAllMedias(2);
+    let videos = faker.build();
+    videos.forEach((video) => {
+      expect(video.videoId).toBeInstanceOf(VideoId);
+      expect(typeof video.title === 'string').toBeTruthy();
+      expect(typeof video.description === 'string').toBeTruthy();
+      expect(typeof video.releasedYear === 'number').toBeTruthy();
+      expect(typeof video.duration === 'number').toBeTruthy();
+      expect(video.rating).toEqual(Rating.createRL());
+      expect(video.isOpened).toBeTruthy();
+      expect(video.isPublished).toBeFalsy();
+      expect(video.banner).toBeInstanceOf(Banner);
+      expect(video.thumbnail).toBeInstanceOf(Thumbnail);
+      expect(video.thumbnailHalf).toBeInstanceOf(ThumbnailHalf);
+      expect(video.trailer).toBeInstanceOf(Trailer);
+      expect(video.video).toBeInstanceOf(VideoMedia);
+      expect(video.categoriesId).toBeInstanceOf(Map);
+      expect(video.categoriesId.size).toBe(1);
+      expect(video.categoriesId.values().next().value).toBeInstanceOf(
+        CategoryId,
+      );
+      expect(video.genresId).toBeInstanceOf(Map);
+      expect(video.genresId.size).toBe(1);
+      expect(video.genresId.values().next().value).toBeInstanceOf(GenreId);
+      expect(video.castMembersId).toBeInstanceOf(Map);
+      expect(video.castMembersId.size).toBe(1);
+      expect(video.castMembersId.values().next().value).toBeInstanceOf(
+        CastMemberId,
+      );
+      expect(video.createdAt).toBeInstanceOf(Date);
+    });
+
+    const createdAt = new Date();
+    const videoId = new VideoId();
+    const categoryId1 = new CategoryId();
+    const categoryId2 = new CategoryId();
+    const genreId1 = new GenreId();
+    const genreId2 = new GenreId();
+    const castMemberId1 = new CastMemberId();
+    const castMemberId2 = new CastMemberId();
+    const banner = new Banner({
+      location: 'location',
+      name: 'name',
+    });
+    const thumbnail = new Thumbnail({
+      location: 'location',
+      name: 'name',
+    });
+    const thumbnailHalf = new ThumbnailHalf({
+      location: 'location',
+      name: 'name',
+    });
+    const trailer = Trailer.create({
+      rawLocation: 'rawLocation',
+      name: 'name',
+    });
+    const videoMedia = VideoMedia.create({
+      rawLocation: 'rawLocation',
+      name: 'name',
+    });
+    videos = VideoFakeBuilder.theVideosWithAllMedias(2)
+      .withVideoId(videoId)
+      .withTitle('name test')
+      .withDescription('description test')
+      .withReleasedYear(2020)
+      .withDuration(90)
+      .withRating(Rating.createR10())
+      .withMarkAsClosed()
+      .addCategoryId(categoryId1)
+      .addCategoryId(categoryId2)
+      .addGenreId(genreId1)
+      .addGenreId(genreId2)
+      .addCastMemberId(castMemberId1)
+      .addCastMemberId(castMemberId2)
+      .withBanner(banner)
+      .withThumbnail(thumbnail)
+      .withThumbnailHalf(thumbnailHalf)
+      .withTrailer(trailer)
+      .withVideo(videoMedia)
+      .withCreatedAt(createdAt)
+      .build();
+    videos.forEach((video) => {
+      expect(video.videoId.id).toBe(videoId.id);
+      expect(video.title).toBe('name test');
+      expect(video.description).toBe('description test');
+      expect(video.releasedYear).toBe(2020);
+      expect(video.duration).toBe(90);
+      expect(video.rating).toEqual(Rating.createR10());
+      expect(video.isOpened).toBeFalsy();
+      expect(video.isPublished).toBeFalsy();
+      expect(video.banner).toBe(banner);
+      expect(video.thumbnail).toBe(thumbnail);
+      expect(video.thumbnailHalf).toBe(thumbnailHalf);
+      expect(video.trailer).toBe(trailer);
+      expect(video.video).toBe(videoMedia);
+      expect(video.categoriesId).toBeInstanceOf(Map);
+      expect(video.categoriesId.get(categoryId1.id)).toBe(categoryId1);
+      expect(video.categoriesId.get(categoryId2.id)).toBe(categoryId2);
+      expect(video.genresId).toBeInstanceOf(Map);
+      expect(video.genresId.get(genreId1.id)).toBe(genreId1);
+      expect(video.genresId.get(genreId2.id)).toBe(genreId2);
+      expect(video.castMembersId).toBeInstanceOf(Map);
+      expect(video.castMembersId.get(castMemberId1.id)).toBe(castMemberId1);
+      expect(video.castMembersId.get(castMemberId2.id)).toBe(castMemberId2);
+      expect(video.createdAt).toEqual(createdAt);
+    });
+  });
+});

--- a/src/core/video/domain/banner.vo.ts
+++ b/src/core/video/domain/banner.vo.ts
@@ -1,0 +1,39 @@
+import { Either } from '@core/shared/domain/either';
+import { MediaFileValidator } from '@core/shared/domain/validators/media-file.validator';
+import { ImageMedia } from '@core/shared/domain/value-objects/image-media.vo';
+
+export class Banner extends ImageMedia {
+  static maxSize = 1024 * 1024 * 2; // 2MB
+
+  static mimeTypes = ['image/jpeg', 'image/png', 'image/gif'];
+
+  static createFromFile({
+    rawName,
+    mimeType,
+    size,
+    videoId,
+  }: {
+    rawName: string;
+    mimeType: string;
+    size: number;
+    videoId: string;
+  }) {
+    const mediaFileValidator = new MediaFileValidator(
+      Banner.maxSize,
+      Banner.mimeTypes,
+    );
+
+    return Either.safe(() => {
+      const { name: newName } = mediaFileValidator.validate({
+        rawName,
+        mimeType,
+        size,
+      });
+
+      return new Banner({
+        name: newName,
+        location: `videos/${videoId}/imagens`,
+      });
+    });
+  }
+}

--- a/src/core/video/domain/banner.vo.ts
+++ b/src/core/video/domain/banner.vo.ts
@@ -1,6 +1,7 @@
 import { Either } from '@core/shared/domain/either';
 import { MediaFileValidator } from '@core/shared/domain/validators/media-file.validator';
 import { ImageMedia } from '@core/shared/domain/value-objects/image-media.vo';
+import { VideoId } from './video.aggregate';
 
 export class Banner extends ImageMedia {
   static maxSize = 1024 * 1024 * 2; // 2MB
@@ -16,7 +17,7 @@ export class Banner extends ImageMedia {
     rawName: string;
     mimeType: string;
     size: number;
-    videoId: string;
+    videoId: VideoId;
   }) {
     const mediaFileValidator = new MediaFileValidator(
       Banner.maxSize,
@@ -32,7 +33,7 @@ export class Banner extends ImageMedia {
 
       return new Banner({
         name: newName,
-        location: `videos/${videoId}/imagens`,
+        location: `videos/${videoId.id}/imagens`,
       });
     });
   }

--- a/src/core/video/domain/rating.vo.ts
+++ b/src/core/video/domain/rating.vo.ts
@@ -1,0 +1,67 @@
+import { Either } from '@core/shared/domain/either';
+import { ValueObject } from '@core/shared/domain/value-object';
+
+export enum RatingValues {
+  RL = 'L',
+  R10 = '10',
+  R12 = '12',
+  R14 = '14',
+  R16 = '16',
+  R18 = '18',
+}
+
+export class Rating extends ValueObject {
+  constructor(readonly value: RatingValues) {
+    super();
+
+    this.validate();
+  }
+
+  private validate() {
+    const isValid = Object.values(RatingValues).includes(this.value);
+
+    if (!isValid) {
+      throw new InvalidRatingError(this.value);
+    }
+  }
+
+  static create(value: RatingValues): Either<Rating, Error> {
+    return Either.safe(() => new Rating(value));
+  }
+
+  static createRL() {
+    return new Rating(RatingValues.RL);
+  }
+
+  static createR10() {
+    return new Rating(RatingValues.R10);
+  }
+
+  static createR12() {
+    return new Rating(RatingValues.R12);
+  }
+
+  static createR14() {
+    return new Rating(RatingValues.R14);
+  }
+
+  static createR16() {
+    return new Rating(RatingValues.R16);
+  }
+
+  static createR18() {
+    return new Rating(RatingValues.R18);
+  }
+
+  static with = (value: RatingValues) => new Rating(value);
+}
+
+export class InvalidRatingError extends Error {
+  constructor(value: any) {
+    super(
+      `The rating must be one of following values: ${Object.values(
+        RatingValues,
+      ).join(', ')}, passed value: ${value}`,
+    );
+  }
+}

--- a/src/core/video/domain/thumbnail-half.vo.ts
+++ b/src/core/video/domain/thumbnail-half.vo.ts
@@ -1,0 +1,47 @@
+import { ImageMedia } from '@core/shared/domain/value-objects/image-media.vo';
+import { VideoId } from './video.aggregate';
+import {
+  InvalidMediaFileMimeTypeError,
+  InvalidMediaFileSizeError,
+  MediaFileValidator,
+} from '@core/shared/domain/validators/media-file.validator';
+import { Either } from '@core/shared/domain/either';
+
+export class ThumbnailHalf extends ImageMedia {
+  static maxSize = 1024 * 1024 * 2; // 2MB
+
+  static mimeTypes = ['image/jpeg', 'image/png'];
+
+  static createFromFile({
+    rawName,
+    mimeType,
+    size,
+    videoId,
+  }: {
+    rawName: string;
+    mimeType: string;
+    size: number;
+    videoId: VideoId;
+  }) {
+    const mediaFileValidator = new MediaFileValidator(
+      ThumbnailHalf.maxSize,
+      ThumbnailHalf.mimeTypes,
+    );
+
+    return Either.safe<
+      ThumbnailHalf,
+      InvalidMediaFileSizeError | InvalidMediaFileMimeTypeError
+    >(() => {
+      const { name } = mediaFileValidator.validate({
+        rawName,
+        mimeType,
+        size,
+      });
+
+      return new ThumbnailHalf({
+        name: `${videoId.id}-${name}`,
+        location: `videos/${videoId.id}/thumbnails`,
+      });
+    });
+  }
+}

--- a/src/core/video/domain/thumbnail.vo.ts
+++ b/src/core/video/domain/thumbnail.vo.ts
@@ -1,0 +1,47 @@
+import { ImageMedia } from '@core/shared/domain/value-objects/image-media.vo';
+import { VideoId } from './video.aggregate';
+import {
+  InvalidMediaFileMimeTypeError,
+  InvalidMediaFileSizeError,
+  MediaFileValidator,
+} from '@core/shared/domain/validators/media-file.validator';
+import { Either } from '@core/shared/domain/either';
+
+export class Thumbnail extends ImageMedia {
+  static maxSize = 1024 * 1024 * 2; // 2MB
+
+  static mimeTypes = ['image/jpeg', 'image/png', 'image/gif'];
+
+  static createFromFile({
+    rawName,
+    mimeType,
+    size,
+    videoId,
+  }: {
+    rawName: string;
+    mimeType: string;
+    size: number;
+    videoId: VideoId;
+  }) {
+    const mediaFileValidator = new MediaFileValidator(
+      Thumbnail.maxSize,
+      Thumbnail.mimeTypes,
+    );
+
+    return Either.safe<
+      Thumbnail,
+      InvalidMediaFileSizeError | InvalidMediaFileMimeTypeError
+    >(() => {
+      const { name } = mediaFileValidator.validate({
+        rawName,
+        mimeType,
+        size,
+      });
+
+      return new Thumbnail({
+        name: `${videoId.id}-${name}`,
+        location: `videos/${videoId.id}/thumbnails`,
+      });
+    });
+  }
+}

--- a/src/core/video/domain/trailer.vo.ts
+++ b/src/core/video/domain/trailer.vo.ts
@@ -1,0 +1,78 @@
+import {
+  AudioVideoMedia,
+  AudioVideoMediaStatus,
+} from '@core/shared/domain/value-objects/audio-video-media.vo';
+import { VideoId } from './video.aggregate';
+import { MediaFileValidator } from '@core/shared/domain/validators/media-file.validator';
+import { Either } from '@core/shared/domain/either';
+
+export class Trailer extends AudioVideoMedia {
+  static maxSize = 1024 * 1024 * 500; // 500MB
+
+  static mimeTypes = ['video/mp4'];
+
+  static createFromFile({
+    rawName,
+    mimeType,
+    size,
+    videoId,
+  }: {
+    rawName: string;
+    mimeType: string;
+    size: number;
+    videoId: VideoId;
+  }) {
+    const mediaFileValidator = new MediaFileValidator(
+      Trailer.maxSize,
+      Trailer.mimeTypes,
+    );
+
+    return Either.safe(() => {
+      const { name: newName } = mediaFileValidator.validate({
+        rawName,
+        mimeType,
+        size,
+      });
+
+      return Trailer.create({
+        name: `${videoId.id}-${newName}`,
+        rawLocation: `videos/${videoId.id}/videos`,
+      });
+    });
+  }
+
+  static create({ name, rawLocation }) {
+    return new Trailer({
+      name,
+      rawLocation,
+      status: AudioVideoMediaStatus.PENDING,
+    });
+  }
+
+  process() {
+    return new Trailer({
+      name: this.name,
+      rawLocation: this.rawLocation,
+      encodedLocation: this.encodedLocation!,
+      status: AudioVideoMediaStatus.PROCESSING,
+    });
+  }
+
+  complete(encodedLocation: string) {
+    return new Trailer({
+      name: this.name,
+      rawLocation: this.rawLocation,
+      encodedLocation,
+      status: AudioVideoMediaStatus.COMPLETED,
+    });
+  }
+
+  fail() {
+    return new Trailer({
+      name: this.name,
+      rawLocation: this.rawLocation,
+      encodedLocation: this.encodedLocation!,
+      status: AudioVideoMediaStatus.FAILED,
+    });
+  }
+}

--- a/src/core/video/domain/video-fake.builder.ts
+++ b/src/core/video/domain/video-fake.builder.ts
@@ -1,0 +1,416 @@
+import { CastMemberId } from '@core/cast-member/domain/cast-member.aggregate';
+import { CategoryId } from '@core/category/domain/category.aggregate';
+import { GenreId } from '@core/genre/domain/genre.aggregate';
+import { Chance } from 'chance';
+import { Banner } from './banner.vo';
+import { Rating } from './rating.vo';
+import { ThumbnailHalf } from './thumbnail-half.vo';
+import { Thumbnail } from './thumbnail.vo';
+import { Trailer } from './trailer.vo';
+import { VideoMedia } from './video-media.vo';
+import { Video, VideoId } from './video.aggregate';
+
+type PropOrFactory<T> = T | ((index: number) => T);
+
+export class VideoFakeBuilder<TBuild = any> {
+  private _videoId: PropOrFactory<VideoId> | undefined = undefined;
+  private _title: PropOrFactory<string> = (_index) => this.chance.word();
+  private _description: PropOrFactory<string> = (_index) =>
+    this.chance.paragraph();
+  private _releasedYear: PropOrFactory<number> = (_index) =>
+    +this.chance.year();
+  private _duration: PropOrFactory<number> = (_index) =>
+    this.chance.integer({ min: 1, max: 100 });
+  private _rating: PropOrFactory<Rating> = (_index) => Rating.createRL();
+  private _isOpened: PropOrFactory<boolean> = (_index) => true;
+  private _banner: PropOrFactory<Banner | null> | undefined = new Banner({
+    name: 'test-name-banner.png',
+    location: 'test path banner',
+  });
+  private _thumbnail: PropOrFactory<Thumbnail | null> | undefined =
+    new Thumbnail({
+      name: 'test-name-thumbnail.png',
+      location: 'test path thumbnail',
+    });
+  private _thumbnailHalf: PropOrFactory<ThumbnailHalf | null> | undefined =
+    new ThumbnailHalf({
+      name: 'test-name-thumbnail-half.png',
+      location: 'test path thumbnail-half',
+    });
+  private _trailer: PropOrFactory<Trailer | null> | undefined = Trailer.create({
+    name: 'test-name-trailer.mp4',
+    rawLocation: 'test path trailer',
+  });
+  private _video: PropOrFactory<VideoMedia | null> | undefined =
+    VideoMedia.create({
+      name: 'test-name-video.mp4',
+      rawLocation: 'test path video',
+    });
+  private _categoriesId: PropOrFactory<CategoryId>[] = [];
+  private _genresId: PropOrFactory<GenreId>[] = [];
+  private _castMembersId: PropOrFactory<CastMemberId>[] = [];
+  private _createdAt: PropOrFactory<Date> | undefined = undefined;
+
+  private countObjs;
+
+  static aVideoWithoutMedias() {
+    return new VideoFakeBuilder<Video>()
+      .withoutBanner()
+      .withoutThumbnail()
+      .withoutThumbnailHalf()
+      .withoutTrailer()
+      .withoutVideo();
+  }
+
+  static aVideoWithAllMedias() {
+    return new VideoFakeBuilder<Video>();
+  }
+
+  static theVideosWithoutMedias(countObjs: number) {
+    return new VideoFakeBuilder<Video[]>(countObjs)
+      .withoutBanner()
+      .withoutThumbnail()
+      .withoutThumbnailHalf()
+      .withoutTrailer()
+      .withoutVideo();
+  }
+
+  static theVideosWithAllMedias(countObjs: number) {
+    return new VideoFakeBuilder<Video[]>(countObjs);
+  }
+
+  private chance: Chance.Chance;
+
+  private constructor(countObjs: number = 1) {
+    this.countObjs = countObjs;
+    this.chance = Chance();
+  }
+
+  withVideoId(valueOrFactory: PropOrFactory<VideoId>) {
+    this._videoId = valueOrFactory;
+    return this;
+  }
+
+  withTitle(valueOrFactory: PropOrFactory<string>) {
+    this._title = valueOrFactory;
+    return this;
+  }
+
+  withDescription(valueOrFactory: PropOrFactory<string>) {
+    this._description = valueOrFactory;
+    return this;
+  }
+
+  withReleasedYear(valueOrFactory: PropOrFactory<number>) {
+    this._releasedYear = valueOrFactory;
+    return this;
+  }
+
+  withDuration(valueOrFactory: PropOrFactory<number>) {
+    this._duration = valueOrFactory;
+    return this;
+  }
+
+  withRating(valueOrFactory: PropOrFactory<Rating>) {
+    this._rating = valueOrFactory;
+    return this;
+  }
+
+  withMarkAsOpened() {
+    this._isOpened = true;
+    return this;
+  }
+
+  withMarkAsClosed() {
+    this._isOpened = false;
+    return this;
+  }
+
+  withBanner(valueOrFactory: PropOrFactory<Banner | null>) {
+    this._banner = valueOrFactory;
+    return this;
+  }
+
+  withoutBanner() {
+    this._banner = null;
+    return this;
+  }
+
+  withThumbnail(valueOrFactory: PropOrFactory<Thumbnail | null>) {
+    this._thumbnail = valueOrFactory;
+    return this;
+  }
+
+  withoutThumbnail() {
+    this._thumbnail = null;
+    return this;
+  }
+
+  withThumbnailHalf(valueOrFactory: PropOrFactory<ThumbnailHalf | null>) {
+    this._thumbnailHalf = valueOrFactory;
+    return this;
+  }
+
+  withoutThumbnailHalf() {
+    this._thumbnailHalf = null;
+    return this;
+  }
+
+  withTrailer(valueOrFactory: PropOrFactory<Trailer | null>) {
+    this._trailer = valueOrFactory;
+    return this;
+  }
+
+  withTrailerComplete() {
+    this._trailer = Trailer.create({
+      name: 'test-name-trailer.mp4',
+      rawLocation: 'test path trailer',
+    }).complete('test encondedLocation trailer');
+    return this;
+  }
+
+  withoutTrailer() {
+    this._trailer = null;
+    return this;
+  }
+
+  withVideo(valueOrFactory: PropOrFactory<VideoMedia | null>) {
+    this._video = valueOrFactory;
+    return this;
+  }
+
+  withVideoComplete() {
+    this._video = VideoMedia.create({
+      name: 'test-name-video.mp4',
+      rawLocation: 'test path video',
+    }).complete('test encondedLocation video');
+    return this;
+  }
+
+  withoutVideo() {
+    this._video = null;
+    return this;
+  }
+
+  addCategoryId(valueOrFactory: PropOrFactory<CategoryId>) {
+    this._categoriesId.push(valueOrFactory);
+    return this;
+  }
+
+  addGenreId(valueOrFactory: PropOrFactory<GenreId>) {
+    this._genresId.push(valueOrFactory);
+    return this;
+  }
+
+  addCastMemberId(valueOrFactory: PropOrFactory<CastMemberId>) {
+    this._castMembersId.push(valueOrFactory);
+    return this;
+  }
+
+  withInvalidTitleTooLong(value?: string) {
+    this._title = value ?? this.chance.word({ length: 256 });
+    return this;
+  }
+
+  withCreatedAt(valueOrFactory: PropOrFactory<Date>) {
+    this._createdAt = valueOrFactory;
+    return this;
+  }
+
+  build(): TBuild {
+    const videos = new Array(this.countObjs).fill(undefined).map((_, index) => {
+      const categoryId = new CategoryId();
+      const categoriesId = this._categoriesId.length
+        ? this.callFactory(this._categoriesId, index)
+        : [categoryId];
+
+      const genreId = new GenreId();
+      const genresId = this._genresId.length
+        ? this.callFactory(this._genresId, index)
+        : [genreId];
+
+      const castMemberId = new CastMemberId();
+      const castMembersId = this._castMembersId.length
+        ? this.callFactory(this._castMembersId, index)
+        : [castMemberId];
+
+      const video = Video.create({
+        title: this.callFactory(this._title, index),
+        description: this.callFactory(this._description, index),
+        releasedYear: this.callFactory(this._releasedYear, index),
+        duration: this.callFactory(this._duration, index),
+        rating: this.callFactory(this._rating, index),
+        isOpened: this.callFactory(this._isOpened, index),
+        banner: this.callFactory(this._banner, index),
+        thumbnail: this.callFactory(this._thumbnail, index),
+        thumbnailHalf: this.callFactory(this._thumbnailHalf, index),
+        trailer: this.callFactory(this._trailer, index),
+        video: this.callFactory(this._video, index),
+        categoriesId,
+        genresId,
+        castMembersId,
+        ...(this._createdAt && {
+          createdAt: this.callFactory(this._createdAt, index),
+        }),
+      });
+
+      video['videoId'] = !this._videoId
+        ? video['videoId']
+        : this.callFactory(this._videoId, index);
+
+      video.validate();
+
+      return video;
+    });
+
+    return this.countObjs === 1 ? (videos[0] as any) : videos;
+  }
+
+  get videoId() {
+    return this.getValue('videoId');
+  }
+
+  get title() {
+    return this.getValue('title');
+  }
+
+  get description() {
+    return this.getValue('description');
+  }
+
+  get releasedYear() {
+    return this.getValue('releasedYear');
+  }
+
+  get duration() {
+    return this.getValue('duration');
+  }
+
+  get rating() {
+    return this.getValue('rating');
+  }
+
+  get isOpened() {
+    return this.getValue('isOpened');
+  }
+
+  get banner() {
+    const banner = this.getValue('banner');
+
+    return (
+      banner ??
+      new Banner({
+        name: 'test-name-banner.png',
+        location: 'test path banner',
+      })
+    );
+  }
+
+  get thumbnail() {
+    const thumbnail = this.getValue('thumbnail');
+
+    return (
+      thumbnail ??
+      new Thumbnail({
+        name: 'test-name-thumbnail.png',
+        location: 'test path thumbnail',
+      })
+    );
+  }
+
+  get thumbnailHalf() {
+    const thumbnailHalf = this.getValue('thumbnailHalf');
+
+    return (
+      thumbnailHalf ??
+      new ThumbnailHalf({
+        name: 'test-name-thumbnail-half.png',
+        location: 'test path thumbnail-half',
+      })
+    );
+  }
+
+  get trailer() {
+    const trailer = this.getValue('trailer');
+
+    return (
+      trailer ??
+      Trailer.create({
+        name: 'test-name-trailer.mp4',
+        rawLocation: 'test path trailer',
+      })
+    );
+  }
+
+  get video() {
+    const video = this.getValue('video');
+
+    return (
+      video ??
+      VideoMedia.create({
+        name: 'test-name-video.mp4',
+        rawLocation: 'test path video',
+      })
+    );
+  }
+
+  get categoriesId(): CategoryId[] {
+    const categoriesId = this.getValue('categoriesId');
+
+    if (!categoriesId.length) {
+      return [new CategoryId()];
+    }
+
+    return categoriesId;
+  }
+
+  get genresId() {
+    const genresId = this.getValue('genresId');
+
+    if (!genresId.length) {
+      return [new GenreId()];
+    }
+
+    return genresId;
+  }
+
+  get castMembersId() {
+    const castMembersId = this.getValue('castMembersId');
+
+    if (!castMembersId.length) {
+      return [new CastMemberId()];
+    }
+
+    return castMembersId;
+  }
+
+  get createdAt() {
+    return this.getValue('createdAt');
+  }
+
+  private getValue(prop: any) {
+    const optional = ['videoId', 'createdAt'];
+
+    const privateProp = `_${prop}` as keyof this;
+
+    if (!this[privateProp] && optional.includes(prop)) {
+      throw new Error(
+        `Property ${prop} not have a factory, use 'with' methods`,
+      );
+    }
+
+    return this.callFactory(this[privateProp], 0);
+  }
+
+  private callFactory(factoryOrValue: PropOrFactory<any>, index: number) {
+    if (typeof factoryOrValue === 'function') {
+      return factoryOrValue(index);
+    }
+
+    if (factoryOrValue instanceof Array) {
+      return factoryOrValue.map((value) => this.callFactory(value, index));
+    }
+
+    return factoryOrValue;
+  }
+}

--- a/src/core/video/domain/video-media.vo.ts
+++ b/src/core/video/domain/video-media.vo.ts
@@ -1,0 +1,78 @@
+import {
+  AudioVideoMedia,
+  AudioVideoMediaStatus,
+} from '@core/shared/domain/value-objects/audio-video-media.vo';
+import { VideoId } from './video.aggregate';
+import { MediaFileValidator } from '@core/shared/domain/validators/media-file.validator';
+import { Either } from '@core/shared/domain/either';
+
+export class VideoMedia extends AudioVideoMedia {
+  static maxSize = 1024 * 1024 * 1024 * 50; // 50GB
+
+  static mimeTypes = ['video/mp4'];
+
+  static createFromFile({
+    rawName,
+    mimeType,
+    size,
+    videoId,
+  }: {
+    rawName: string;
+    mimeType: string;
+    size: number;
+    videoId: VideoId;
+  }) {
+    const mediaFileValidator = new MediaFileValidator(
+      VideoMedia.maxSize,
+      VideoMedia.mimeTypes,
+    );
+
+    return Either.safe(() => {
+      const { name: newName } = mediaFileValidator.validate({
+        rawName,
+        mimeType,
+        size,
+      });
+
+      return VideoMedia.create({
+        name: `${videoId.id}-${newName}`,
+        rawLocation: `videos/${videoId.id}/videos`,
+      });
+    });
+  }
+
+  static create({ name, rawLocation }) {
+    return new VideoMedia({
+      name,
+      rawLocation,
+      status: AudioVideoMediaStatus.PENDING,
+    });
+  }
+
+  process() {
+    return new VideoMedia({
+      name: this.name,
+      rawLocation: this.rawLocation,
+      encodedLocation: this.encodedLocation!,
+      status: AudioVideoMediaStatus.PROCESSING,
+    });
+  }
+
+  complete(encodedLocation: string) {
+    return new VideoMedia({
+      name: this.name,
+      rawLocation: this.rawLocation,
+      encodedLocation,
+      status: AudioVideoMediaStatus.COMPLETED,
+    });
+  }
+
+  fail() {
+    return new VideoMedia({
+      name: this.name,
+      rawLocation: this.rawLocation,
+      encodedLocation: this.encodedLocation!,
+      status: AudioVideoMediaStatus.FAILED,
+    });
+  }
+}

--- a/src/core/video/domain/video.aggregate.ts
+++ b/src/core/video/domain/video.aggregate.ts
@@ -4,6 +4,7 @@ import { GenreId } from '@core/genre/domain/genre.aggregate';
 import { AggregateRoot } from '@core/shared/domain/aggregate-root';
 import { ValueObject } from '@core/shared/domain/value-object';
 import { Uuid } from '@core/shared/domain/value-objects/uuid.vo';
+import { Banner } from './banner.vo';
 import { Rating } from './rating.vo';
 
 export type VideoConstructorProps = {
@@ -15,6 +16,7 @@ export type VideoConstructorProps = {
   rating: Rating;
   isOpened: boolean;
   isPublished: boolean;
+  banner?: Banner;
   categoriesId: Map<string, CategoryId>;
   genresId: Map<string, GenreId>;
   castMembersId: Map<string, CastMemberId>;
@@ -29,6 +31,7 @@ export type VideoCreateCommand = {
   rating: Rating;
   isOpened: boolean;
   isPublished: boolean;
+  banner?: Banner;
   categoriesId: CategoryId[];
   genresId: GenreId[];
   castMembersId: CastMemberId[];
@@ -45,6 +48,7 @@ export class Video extends AggregateRoot {
   rating: Rating;
   isOpened: boolean;
   isPublished: boolean;
+  banner: Banner | null;
   categoriesId: Map<string, CategoryId>;
   genresId: Map<string, GenreId>;
   castMembersId: Map<string, CastMemberId>;
@@ -60,6 +64,7 @@ export class Video extends AggregateRoot {
     this.rating = props.rating;
     this.isOpened = props.isOpened;
     this.isPublished = props.isPublished;
+    this.banner = props.banner ?? null;
     this.categoriesId = props.categoriesId;
     this.genresId = props.genresId;
     this.castMembersId = props.castMembersId;

--- a/src/core/video/domain/video.aggregate.ts
+++ b/src/core/video/domain/video.aggregate.ts
@@ -8,6 +8,9 @@ import { Banner } from './banner.vo';
 import { Rating } from './rating.vo';
 import { ThumbnailHalf } from './thumbnail-half.vo';
 import { Thumbnail } from './thumbnail.vo';
+import { Trailer } from './trailer.vo';
+import { VideoMedia } from './video-media.vo';
+import VideoValidatorFactory from './video.validator';
 
 export type VideoConstructorProps = {
   videoId?: VideoId;
@@ -21,6 +24,8 @@ export type VideoConstructorProps = {
   banner?: Banner;
   thumbnail?: Thumbnail;
   thumbnailHalf?: ThumbnailHalf;
+  trailer?: Trailer;
+  video?: VideoMedia;
   categoriesId: Map<string, CategoryId>;
   genresId: Map<string, GenreId>;
   castMembersId: Map<string, CastMemberId>;
@@ -38,6 +43,8 @@ export type VideoCreateCommand = {
   banner?: Banner;
   thumbnail?: Thumbnail;
   thumbnailHalf?: ThumbnailHalf;
+  trailer?: Trailer;
+  video?: VideoMedia;
   categoriesId: CategoryId[];
   genresId: GenreId[];
   castMembersId: CastMemberId[];
@@ -57,6 +64,8 @@ export class Video extends AggregateRoot {
   banner: Banner | null;
   thumbnail: Thumbnail | null;
   thumbnailHalf: ThumbnailHalf | null;
+  trailer?: Trailer | null;
+  video?: VideoMedia | null;
   categoriesId: Map<string, CategoryId>;
   genresId: Map<string, GenreId>;
   castMembersId: Map<string, CastMemberId>;
@@ -75,6 +84,8 @@ export class Video extends AggregateRoot {
     this.banner = props.banner ?? null;
     this.thumbnail = props.thumbnail ?? null;
     this.thumbnailHalf = props.thumbnailHalf ?? null;
+    this.trailer = props.trailer ?? null;
+    this.video = props.video ?? null;
     this.categoriesId = props.categoriesId;
     this.genresId = props.genresId;
     this.castMembersId = props.castMembersId;
@@ -94,11 +105,15 @@ export class Video extends AggregateRoot {
       isPublished: false,
     });
 
+    video.validate(['title']);
+
     return video;
   }
 
   changeTitle(title: string) {
     this.title = title;
+
+    this.validate(['title']);
   }
 
   changeDescription(description: string) {
@@ -173,6 +188,12 @@ export class Video extends AggregateRoot {
     this.castMembersId = new Map(castMembersId.map((id) => [id.id, id]));
   }
 
+  validate(fields?: string[]) {
+    const validator = VideoValidatorFactory.create();
+
+    return validator.validate(this.notification, this, fields);
+  }
+
   get entityId(): ValueObject {
     return this.videoId;
   }
@@ -190,6 +211,8 @@ export class Video extends AggregateRoot {
       banner: this.banner ? this.banner.toJSON() : null,
       thumbnail: this.thumbnail ? this.thumbnail.toJSON() : null,
       thumbnailHalf: this.thumbnailHalf ? this.thumbnailHalf.toJSON() : null,
+      trailer: this.trailer ? this.trailer.toJSON() : null,
+      video: this.video ? this.video.toJSON() : null,
       categoriesId: Array.from(this.categoriesId.values()).map((id) => id.id),
       genresId: Array.from(this.genresId.values()).map((id) => id.id),
       castMembersId: Array.from(this.castMembersId.values()).map((id) => id.id),

--- a/src/core/video/domain/video.aggregate.ts
+++ b/src/core/video/domain/video.aggregate.ts
@@ -4,6 +4,7 @@ import { GenreId } from '@core/genre/domain/genre.aggregate';
 import { AggregateRoot } from '@core/shared/domain/aggregate-root';
 import { ValueObject } from '@core/shared/domain/value-object';
 import { Uuid } from '@core/shared/domain/value-objects/uuid.vo';
+import { Rating } from './rating.vo';
 
 export type VideoConstructorProps = {
   videoId?: VideoId;
@@ -11,6 +12,7 @@ export type VideoConstructorProps = {
   description: string;
   releasedYear: number;
   duration: number;
+  rating: Rating;
   isOpened: boolean;
   isPublished: boolean;
   categoriesId: Map<string, CategoryId>;
@@ -24,6 +26,7 @@ export type VideoCreateCommand = {
   description: string;
   releasedYear: number;
   duration: number;
+  rating: Rating;
   isOpened: boolean;
   isPublished: boolean;
   categoriesId: CategoryId[];
@@ -39,6 +42,7 @@ export class Video extends AggregateRoot {
   description: string;
   releasedYear: number;
   duration: number;
+  rating: Rating;
   isOpened: boolean;
   isPublished: boolean;
   categoriesId: Map<string, CategoryId>;
@@ -53,6 +57,7 @@ export class Video extends AggregateRoot {
     this.description = props.description;
     this.releasedYear = props.releasedYear;
     this.duration = props.duration;
+    this.rating = props.rating;
     this.isOpened = props.isOpened;
     this.isPublished = props.isPublished;
     this.categoriesId = props.categoriesId;
@@ -91,6 +96,10 @@ export class Video extends AggregateRoot {
 
   changeDuration(duration: number) {
     this.duration = duration;
+  }
+
+  changeRating(rating: Rating) {
+    this.rating = rating;
   }
 
   markAsOpened() {
@@ -160,6 +169,7 @@ export class Video extends AggregateRoot {
       description: this.description,
       releasedYear: this.releasedYear,
       duration: this.duration,
+      rating: this.rating.value,
       isOpened: this.isOpened,
       isPublished: this.isPublished,
       categoriesId: Array.from(this.categoriesId.values()).map((id) => id.id),

--- a/src/core/video/domain/video.aggregate.ts
+++ b/src/core/video/domain/video.aggregate.ts
@@ -6,6 +6,8 @@ import { ValueObject } from '@core/shared/domain/value-object';
 import { Uuid } from '@core/shared/domain/value-objects/uuid.vo';
 import { Banner } from './banner.vo';
 import { Rating } from './rating.vo';
+import { ThumbnailHalf } from './thumbnail-half.vo';
+import { Thumbnail } from './thumbnail.vo';
 
 export type VideoConstructorProps = {
   videoId?: VideoId;
@@ -17,6 +19,8 @@ export type VideoConstructorProps = {
   isOpened: boolean;
   isPublished: boolean;
   banner?: Banner;
+  thumbnail?: Thumbnail;
+  thumbnailHalf?: ThumbnailHalf;
   categoriesId: Map<string, CategoryId>;
   genresId: Map<string, GenreId>;
   castMembersId: Map<string, CastMemberId>;
@@ -32,6 +36,8 @@ export type VideoCreateCommand = {
   isOpened: boolean;
   isPublished: boolean;
   banner?: Banner;
+  thumbnail?: Thumbnail;
+  thumbnailHalf?: ThumbnailHalf;
   categoriesId: CategoryId[];
   genresId: GenreId[];
   castMembersId: CastMemberId[];
@@ -49,6 +55,8 @@ export class Video extends AggregateRoot {
   isOpened: boolean;
   isPublished: boolean;
   banner: Banner | null;
+  thumbnail: Thumbnail | null;
+  thumbnailHalf: ThumbnailHalf | null;
   categoriesId: Map<string, CategoryId>;
   genresId: Map<string, GenreId>;
   castMembersId: Map<string, CastMemberId>;
@@ -65,6 +73,8 @@ export class Video extends AggregateRoot {
     this.isOpened = props.isOpened;
     this.isPublished = props.isPublished;
     this.banner = props.banner ?? null;
+    this.thumbnail = props.thumbnail ?? null;
+    this.thumbnailHalf = props.thumbnailHalf ?? null;
     this.categoriesId = props.categoriesId;
     this.genresId = props.genresId;
     this.castMembersId = props.castMembersId;
@@ -177,6 +187,9 @@ export class Video extends AggregateRoot {
       rating: this.rating.value,
       isOpened: this.isOpened,
       isPublished: this.isPublished,
+      banner: this.banner ? this.banner.toJSON() : null,
+      thumbnail: this.thumbnail ? this.thumbnail.toJSON() : null,
+      thumbnailHalf: this.thumbnailHalf ? this.thumbnailHalf.toJSON() : null,
       categoriesId: Array.from(this.categoriesId.values()).map((id) => id.id),
       genresId: Array.from(this.genresId.values()).map((id) => id.id),
       castMembersId: Array.from(this.castMembersId.values()).map((id) => id.id),

--- a/src/core/video/domain/video.aggregate.ts
+++ b/src/core/video/domain/video.aggregate.ts
@@ -40,7 +40,6 @@ export type VideoCreateCommand = {
   duration: number;
   rating: Rating;
   isOpened: boolean;
-  isPublished: boolean;
   banner?: Banner;
   thumbnail?: Thumbnail;
   thumbnailHalf?: ThumbnailHalf;

--- a/src/core/video/domain/video.aggregate.ts
+++ b/src/core/video/domain/video.aggregate.ts
@@ -1,0 +1,171 @@
+import { CastMemberId } from '@core/cast-member/domain/cast-member.aggregate';
+import { CategoryId } from '@core/category/domain/category.aggregate';
+import { GenreId } from '@core/genre/domain/genre.aggregate';
+import { AggregateRoot } from '@core/shared/domain/aggregate-root';
+import { ValueObject } from '@core/shared/domain/value-object';
+import { Uuid } from '@core/shared/domain/value-objects/uuid.vo';
+
+export type VideoConstructorProps = {
+  videoId?: VideoId;
+  title: string;
+  description: string;
+  releasedYear: number;
+  duration: number;
+  isOpened: boolean;
+  isPublished: boolean;
+  categoriesId: Map<string, CategoryId>;
+  genresId: Map<string, GenreId>;
+  castMembersId: Map<string, CastMemberId>;
+  createdAt?: Date;
+};
+
+export type VideoCreateCommand = {
+  title: string;
+  description: string;
+  releasedYear: number;
+  duration: number;
+  isOpened: boolean;
+  isPublished: boolean;
+  categoriesId: CategoryId[];
+  genresId: GenreId[];
+  castMembersId: CastMemberId[];
+};
+
+export class VideoId extends Uuid {}
+
+export class Video extends AggregateRoot {
+  videoId: VideoId;
+  title: string;
+  description: string;
+  releasedYear: number;
+  duration: number;
+  isOpened: boolean;
+  isPublished: boolean;
+  categoriesId: Map<string, CategoryId>;
+  genresId: Map<string, GenreId>;
+  castMembersId: Map<string, CastMemberId>;
+  createdAt: Date;
+
+  constructor(props: VideoConstructorProps) {
+    super();
+    this.videoId = props.videoId ?? new VideoId();
+    this.title = props.title;
+    this.description = props.description;
+    this.releasedYear = props.releasedYear;
+    this.duration = props.duration;
+    this.isOpened = props.isOpened;
+    this.isPublished = props.isPublished;
+    this.categoriesId = props.categoriesId;
+    this.genresId = props.genresId;
+    this.castMembersId = props.castMembersId;
+    this.createdAt = props.createdAt ?? new Date();
+  }
+
+  static create(props: VideoCreateCommand) {
+    const video = new Video({
+      ...props,
+      categoriesId: new Map(
+        props.categoriesId.map((id) => [id.toString(), id]),
+      ),
+      genresId: new Map(props.genresId.map((id) => [id.toString(), id])),
+      castMembersId: new Map(
+        props.castMembersId.map((id) => [id.toString(), id]),
+      ),
+      isPublished: false,
+    });
+
+    return video;
+  }
+
+  changeTitle(title: string) {
+    this.title = title;
+  }
+
+  changeDescription(description: string) {
+    this.description = description;
+  }
+
+  changeReleasedYear(releasedYear: number) {
+    this.releasedYear = releasedYear;
+  }
+
+  changeDuration(duration: number) {
+    this.duration = duration;
+  }
+
+  markAsOpened() {
+    this.isOpened = true;
+  }
+
+  markAsClosed() {
+    this.isOpened = false;
+  }
+
+  addCategoryId(categoryId: CategoryId) {
+    this.categoriesId.set(categoryId.id, categoryId);
+  }
+
+  removeCategoryId(categoryId: CategoryId) {
+    this.categoriesId.delete(categoryId.id);
+  }
+
+  syncCategoriesId(categoriesId: CategoryId[]) {
+    if (!categoriesId.length) {
+      throw new Error('Categories id is empty');
+    }
+
+    this.categoriesId = new Map(categoriesId.map((id) => [id.id, id]));
+  }
+
+  addGenreId(genreId: GenreId) {
+    this.genresId.set(genreId.id, genreId);
+  }
+
+  removeGenreId(genreId: GenreId) {
+    this.genresId.delete(genreId.id);
+  }
+
+  syncGenresId(genresId: GenreId[]) {
+    if (!genresId.length) {
+      throw new Error('Genres id is empty');
+    }
+
+    this.genresId = new Map(genresId.map((id) => [id.id, id]));
+  }
+
+  addCastMemberId(castMemberId: CastMemberId) {
+    this.castMembersId.set(castMemberId.id, castMemberId);
+  }
+
+  removeCastMemberId(castMemberId: CastMemberId) {
+    this.castMembersId.delete(castMemberId.id);
+  }
+
+  syncCastMembersId(castMembersId: CastMemberId[]) {
+    if (!castMembersId.length) {
+      throw new Error('Cast members id is empty');
+    }
+
+    this.castMembersId = new Map(castMembersId.map((id) => [id.id, id]));
+  }
+
+  get entityId(): ValueObject {
+    return this.videoId;
+  }
+
+  toJSON() {
+    return {
+      videoId: this.videoId.id,
+      title: this.title,
+      description: this.description,
+      releasedYear: this.releasedYear,
+      duration: this.duration,
+      isOpened: this.isOpened,
+      isPublished: this.isPublished,
+      categoriesId: Array.from(this.categoriesId.values()).map((id) => id.id),
+      genresId: Array.from(this.genresId.values()).map((id) => id.id),
+      castMembersId: Array.from(this.castMembersId.values()).map((id) => id.id),
+      createdAt: this.createdAt,
+    };
+  }
+}

--- a/src/core/video/domain/video.aggregate.ts
+++ b/src/core/video/domain/video.aggregate.ts
@@ -3,6 +3,7 @@ import { CategoryId } from '@core/category/domain/category.aggregate';
 import { GenreId } from '@core/genre/domain/genre.aggregate';
 import { AggregateRoot } from '@core/shared/domain/aggregate-root';
 import { ValueObject } from '@core/shared/domain/value-object';
+import { AudioVideoMediaStatus } from '@core/shared/domain/value-objects/audio-video-media.vo';
 import { Uuid } from '@core/shared/domain/value-objects/uuid.vo';
 import { Banner } from './banner.vo';
 import { Rating } from './rating.vo';
@@ -107,6 +108,8 @@ export class Video extends AggregateRoot {
 
     video.validate(['title']);
 
+    video.markAsPublished();
+
     return video;
   }
 
@@ -138,6 +141,37 @@ export class Video extends AggregateRoot {
 
   markAsClosed() {
     this.isOpened = false;
+  }
+
+  replaceBanner(banner: Banner): void {
+    this.banner = banner;
+  }
+
+  replaceThumbnail(thumbnail: Thumbnail): void {
+    this.thumbnail = thumbnail;
+  }
+
+  replaceThumbnailHalf(thumbnailHalf: ThumbnailHalf): void {
+    this.thumbnailHalf = thumbnailHalf;
+  }
+
+  replaceTrailer(trailer: Trailer): void {
+    this.trailer = trailer;
+  }
+
+  replaceVideo(video: VideoMedia): void {
+    this.video = video;
+  }
+
+  private markAsPublished() {
+    if (
+      this.trailer &&
+      this.video &&
+      this.trailer.status === AudioVideoMediaStatus.COMPLETED &&
+      this.video.status === AudioVideoMediaStatus.COMPLETED
+    ) {
+      this.isPublished = true;
+    }
   }
 
   addCategoryId(categoryId: CategoryId) {

--- a/src/core/video/domain/video.validator.ts
+++ b/src/core/video/domain/video.validator.ts
@@ -1,0 +1,33 @@
+import { MaxLength } from 'class-validator';
+import { Video } from './video.aggregate';
+import { ClassValidatorFields } from '@core/shared/domain/validators/class-validator-fields';
+import { Notification } from '@core/shared/domain/validators/notification';
+
+export class VideoRules {
+  @MaxLength(255, { groups: ['title'] })
+  title: string;
+
+  constructor(aggregate: Video) {
+    Object.assign(this, aggregate);
+  }
+}
+
+export class VideoValidator extends ClassValidatorFields {
+  validate(
+    notification: Notification,
+    data: Video,
+    fields?: string[],
+  ): boolean {
+    const newFields = fields?.length ? fields : ['title'];
+
+    return super.validate(notification, new VideoRules(data), newFields);
+  }
+}
+
+export class VideoValidatorFactory {
+  static create() {
+    return new VideoValidator();
+  }
+}
+
+export default VideoValidatorFactory;

--- a/src/nest-modules/shared-module/filters/not-found-error.filter.spec.ts
+++ b/src/nest-modules/shared-module/filters/not-found-error.filter.spec.ts
@@ -6,7 +6,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import request from 'supertest';
 
 class StubEntity extends Entity {
-  entityID: any;
+  entityId: any;
 
   toJSON(): Required<any> {
     return {};


### PR DESCRIPTION
## Description
Adding entity for video.
## Details
### Changes
[[`9c91040`](https://github.com/douglastenfen/ms-admin-catalogo-videos-ts/commit/9c91040)] - add: video entity
- Changed nomenclature from `entityID` to `entityId` in some files.
- Added video entity.

[[`f6a0c43`](https://github.com/douglastenfen/ms-admin-catalogo-videos-ts/commit/f6a0c43)] - add: rating value object
- Added value object for video rating.

[[`828ad99`](https://github.com/douglastenfen/ms-admin-catalogo-videos-ts/commit/828ad99)] - add: value object to abstract images uploads
- Added value object for images.

[[`9bb6add`](https://github.com/douglastenfen/ms-admin-catalogo-videos-ts/commit/9bb6add)] - add: value object to video banner
- Added value object for video banner

[[`82ff95a`](https://github.com/douglastenfen/ms-admin-catalogo-videos-ts/commit/82ff95a)] - add: other value objects for the video images
- Added value objects for thumbnails.

[[`27465ee`](https://github.com/douglastenfen/ms-admin-catalogo-videos-ts/commit/27465ee)] - add: value object to abstract audio visual files
- Added value object for audio visual files.

[[`7deb896`](https://github.com/douglastenfen/ms-admin-catalogo-videos-ts/commit/7deb896)] - add: value objects for trailer and videos
- Added value objects for trailer and video media.

[[`c982b24`](https://github.com/douglastenfen/ms-admin-catalogo-videos-ts/commit/c982b24)] - add: validation service for video
- Added validator class for video entity.

[[`28e95bc`](https://github.com/douglastenfen/ms-admin-catalogo-videos-ts/commit/28e95bc)] - add validations for upload fields
- Added validations and methods that apply the business rules.

[[`ea16e92`](https://github.com/douglastenfen/ms-admin-catalogo-videos-ts/commit/ea16e92)] - add test data builder
- Added test data builder